### PR TITLE
gem/font-awesome-delete

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,6 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'haml-rails'
 gem 'erb2haml'
-gem 'font-awesome-sass', '~> 5.11.2'
 gem 'font-awesome-rails'
 gem 'chartkick', '~> 3.2', '>= 3.2.1'
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,8 +93,8 @@ GEM
     ffi (1.11.3)
     font-awesome-rails (4.7.0.5)
       railties (>= 3.2, < 6.1)
-    font-awesome-sass (5.11.2)
-      sassc (>= 1.11)
+    font-awesome-sassc (4.7.1)
+      sass (>= 3.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     gon (6.3.2)
@@ -221,8 +221,6 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sassc (2.2.1)
-      ffi (~> 1.9)
     selenium-webdriver (3.142.6)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -279,7 +277,7 @@ DEPENDENCIES
   devise
   erb2haml
   font-awesome-rails
-  font-awesome-sass (~> 5.11.2)
+  font-awesome-sassc (~> 4.7, >= 4.7.1)
   gon
   haml-rails
   jbuilder (~> 2.5)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,7 +17,6 @@
 @import "./config/option";
 @import "./modules/reset";
 @import "font-awesome";
-@import "font-awesome-sprockets";
 @import "./modules/messages";
 @import "./modules/new";
 @import "./modules/numbers";


### PR DESCRIPTION
#what 
・font-awesome-sassをgemから削除しました。

#why 
・本番環境でエラーが起きたからです。