### PR TITLE
gitignore-edit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,8 @@
 /public/assets
 .byebug_history
 
+
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+vendor/bundle


### PR DESCRIPTION
#what
・gitignoreにvendorディレクトリを追加しました。

#why
・bundle install時にvendor/bundleのフォルダが大量生成されてコミット・プッシュできなかったからです。