### PR TITLE
gem-confirmation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,7 @@ gem "kaminari"
 gem 'bootstrap4-kaminari-views'
 
 
+
 group :production do
   gem 'unicorn', '5.4.1'
 end


### PR DESCRIPTION
#What
・vendoy/bundleを削除しました。

#Why
・vendoy/bundleのフォルダが存在する環境で、本番環境でrake db:seedコマンドが通らなかったからです。