### PR TITLE
delete turbolinks

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,7 +11,7 @@
     %link{:href => "//cdn.jsdelivr.net/gh/kenwheeler/slick@1.8.1/slick/slick.css", :rel => "stylesheet", :type => "text/css"}
     %link{:href => "//cdn.jsdelivr.net/gh/kenwheeler/slick@1.8.1/slick/slick-theme.css", :rel => "stylesheet", :type => "text/css"}
     %script{:src => "https://cdn.jsdelivr.net/npm/chart.js@2.8.0"}
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
+    = javascript_include_tag 'application'
+    = stylesheet_link_tag    'application', media: 'all'
   %body
     = yield


### PR DESCRIPTION
# What
・　application.html.hamlのturbolinksを削除しました。

# Why
・　slickが本番環境で動作しないのがturbolinksの影響だと考えたからです。